### PR TITLE
Adjust mobile spacing for pitch deck controls

### DIFF
--- a/pitch.html
+++ b/pitch.html
@@ -255,7 +255,7 @@
               </button>
             </div>
 
-            <div class="space-y-8 sm:space-y-12">
+            <div class="space-y-0 sm:space-y-12">
                 <article class="slide slide-active" data-slide="1" aria-hidden="false">
                   <div class="max-w-4xl mx-auto rounded-3xl bg-white/5 ring-1 ring-white/10 shadow-xl shadow-indigo-500/10 overflow-hidden print-friendly">
                     <div class="p-8 sm:p-12 flex flex-col gap-8">

--- a/pitch.html
+++ b/pitch.html
@@ -171,7 +171,7 @@
       ></div>
     </div>
 
-    <header class="max-w-6xl mx-auto px-6 py-6 flex items-center justify-between">
+    <header class="max-w-6xl mx-auto px-6 py-4 sm:py-6 flex items-center justify-between">
       <div class="flex items-center gap-3">
         <span class="grid place-items-center h-10 w-10 rounded-2xl bg-gradient-to-br from-white/10 to-white/5 ring-1 ring-white/10 shadow-glow">
           <span class="text-lg font-bold tracking-tight">L</span>
@@ -188,7 +188,7 @@
     </header>
 
     <main class="px-6 pb-6">
-      <section class="max-w-6xl mx-auto pt-4">
+      <section class="max-w-6xl mx-auto pt-2 sm:pt-4">
         <div
           id="deck"
           class="relative"
@@ -196,7 +196,7 @@
           aria-roledescription="carousel"
           aria-label="Lavrenko investor pitch deck"
         >
-          <div class="flex flex-col gap-6">
+          <div class="flex flex-col gap-4 sm:gap-6">
             <div class="flex w-full items-center gap-3 sm:gap-4">
               <button
                 id="prev-slide"
@@ -255,7 +255,7 @@
               </button>
             </div>
 
-            <div class="space-y-12">
+            <div class="space-y-8 sm:space-y-12">
                 <article class="slide slide-active" data-slide="1" aria-hidden="false">
                   <div class="max-w-4xl mx-auto rounded-3xl bg-white/5 ring-1 ring-white/10 shadow-xl shadow-indigo-500/10 overflow-hidden print-friendly">
                     <div class="p-8 sm:p-12 flex flex-col gap-8">


### PR DESCRIPTION
## Summary
- reduce header padding on small screens to tighten the mobile viewport
- shrink vertical spacing around the carousel controls and slides on mobile while preserving desktop layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9334505148333ac35ada4386abd2d