### PR TITLE
Refine slide 9 team layout

### DIFF
--- a/pitch.html
+++ b/pitch.html
@@ -550,23 +550,36 @@
                 <article class="slide" data-slide="9" aria-hidden="true">
               <div class="max-w-5xl mx-auto slide-card space-y-6 print-friendly">
                 <div class="flex flex-wrap items-center gap-3 text-xs font-semibold uppercase tracking-[0.2em] text-accent-200/80">
-                  <span class="chip">Slide 9 • Team &amp; Roadmap</span>
-                  <span class="chip">Execution</span>
+                  <span class="chip">Slide 9 • Team</span>
                 </div>
-                <div class="grid gap-6 sm:grid-cols-2">
-                  <div class="space-y-4">
-                    <h2 class="text-2xl sm:text-3xl font-semibold text-white">Operator-led team</h2>
-                    <p class="text-base text-zinc-300/90">
-                      Victor Lavrenko — ex-Cốc Cốc (built 30M-MAU browser against Chrome, exited 2018). Pipeline of ex-Cốc Cốc engineers ready to rejoin.
-                    </p>
-                  </div>
-                  <div class="space-y-4">
-                    <h3 class="text-lg font-semibold text-white">Roadmap</h3>
-                    <ul class="space-y-3 text-sm text-zinc-300/85">
-                      <li>0–6 mo: extension + engagement measurement pilots.</li>
-                      <li>6–12 mo: secure browser wrapper + compliance packs.</li>
-                      <li>12–18 mo: full AI-native enterprise browser with engagement orchestration.</li>
-                    </ul>
+                <div class="space-y-6">
+                  <h2 class="text-2xl sm:text-3xl font-semibold text-white"><strong>Winning team, ready to ship</strong></h2>
+                  <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-[0.9fr_1.1fr]">
+                    <div class="surface-panel relative h-full overflow-hidden space-y-4">
+                      <div class="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-accent-500/80 via-accent-500/40 to-transparent"></div>
+                      <p class="text-lg font-semibold text-white"><strong>Victor Lavrenko — Founder/CEO</strong></p>
+                      <ul class="space-y-3 text-sm text-zinc-300/85">
+                        <li>Co-founder &amp; CEO, Cốc Cốc Browser/Search (30M+ MAU, 30% desktop share, profitable vs. Chrome/Firefox).</li>
+                        <li>Ex-Nigma.ru, Mail.ru ($6B IPO), Mango Techsurance.</li>
+                        <li>Operator with a proven track record of scaling distribution-first consumer tech into enterprise-grade monetization.</li>
+                      </ul>
+                    </div>
+                    <div class="grid gap-6 lg:grid-rows-[repeat(2,minmax(0,1fr))]">
+                      <div class="surface-panel relative h-full overflow-hidden space-y-4">
+                        <div class="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-accent-500/70 via-accent-500/30 to-transparent"></div>
+                        <p class="text-lg font-semibold text-white"><strong>Team pipeline</strong></p>
+                        <ul class="space-y-3 text-sm text-zinc-300/85">
+                          <li>Senior engineers and monetization talent from Cốc Cốc, Mango, and successful cybersecurity startups ready to join post-funding.</li>
+                        </ul>
+                      </div>
+                      <div class="surface-panel relative h-full overflow-hidden space-y-4">
+                        <div class="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-accent-500/70 via-accent-500/30 to-transparent"></div>
+                        <p class="text-lg font-semibold text-white"><strong>Advisory / Network</strong></p>
+                        <ul class="space-y-3 text-sm text-zinc-300/85">
+                          <li>Targeting design partners across People Analytics, Data Security, and IAM ecosystems (Visier, TrustLogix, Secuvy, Binarly, ForgeRock, Snowflake, Workday).</li>
+                        </ul>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- refresh slide 9 heading copy to an emotive "Winning team, ready to ship" title while keeping the requested content intact
- tweak the large-screen grid ratios so the founder column tightens and the stacked pipeline/advisory column gains space

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da71e041b883339045d883acddc42e